### PR TITLE
added hihglight js class replacer

### DIFF
--- a/addon/helpers/format-markdown.js
+++ b/addon/helpers/format-markdown.js
@@ -9,7 +9,17 @@ export function formatMarkdown(value) {
     }
   });
 
-  return new Ember.Handlebars.SafeString(window.marked(value));
+  // highlight JS requires the following classes for code highlighting
+  // hljs [LANG]. By default, marked places "lang-[LANG]" as a class on the code
+  // html element. This will search and replace all instances of that class
+  // with proper hljs code classes
+  // ex.
+  // input: ```javascript\nsomeJavascript()\n```
+  // will result in a class: <code class="lang-javascript"></code>
+  // and after the following replace: <code class "lang-javascript hljs javascript">...
+  var parsedMarkdown = window.marked(value).replace( /lang-(\w+)/g, "lang-$1 hljs $1");
+
+  return new Ember.Handlebars.SafeString(parsedMarkdown);
 }
 
 export default Ember.Handlebars.makeBoundHelper(formatMarkdown);

--- a/tests/unit/helpers/format-markdown-test.js
+++ b/tests/unit/helpers/format-markdown-test.js
@@ -16,5 +16,5 @@ test('it should format markdown code to HTML and highlight it', function(assert)
   var result = formatMarkdown("```javascript \n var that = this;```");
 
   assert.ok(result);
-  assert.equal(result.string.trim(), '<pre><code class="lang-javascript"> <span class="hljs-keyword">var</span> <span class="hljs-literal">that</span> = <span class="hljs-keyword">this</span>;\n</code></pre>');
+  assert.equal(result.string.trim(), '<pre><code class="lang-javascript hljs javascript"> <span class="hljs-keyword">var</span> <span class="hljs-literal">that</span> = <span class="hljs-keyword">this</span>;\n</code></pre>');
 });


### PR DESCRIPTION
Currently the marked editor supplies the following classes on code elements:

``` html
<code class="lang-javascript"></code>
```

But the HighlightJS lib requires the following additional classes to be added in order to fully implment the highlighting (unless I'm missing something).

``` html
<code class="lang-javascript hljs javascript"></code>
```

I added in a regex replacement to add the above classes. If I am missing something let me know, but this is working for me as expected.
